### PR TITLE
fix: open explore link in new tab

### DIFF
--- a/src/components/modals/ModalInfo.vue
+++ b/src/components/modals/ModalInfo.vue
@@ -15,6 +15,7 @@
       <div class="meta-modal__point-title">Owner</div>
       <a
           :href="`https://basescan.org/address/${item.seed.owner}`"
+          target="_blank"
           class="meta-modal__point-value"
       >
         {{ shortAddress(item.seed.owner) }}


### PR DESCRIPTION
Hi @ToddStool, I'd like to make my first contribution by fixing the link inside the modal to open in a new tab, just like the other links in the app.

<img width="802" alt="image" src="https://github.com/ToddStool/fungi-interface/assets/51686767/f408f4ee-73aa-41b7-a682-c92dc2ef0ba4">
