### PR TITLE
Call formatNumberWithComma directly in inscription list

### DIFF
--- a/src/components/InscriptionList.vue
+++ b/src/components/InscriptionList.vue
@@ -10,7 +10,7 @@
       <div class="inscription-list__item-info">
         <div class="inscription-list__item-title">
           {{ inscription.seed.isDynamic ? 'Dynamic Fungi' : 'Stable Fungi' }}
-          <NumberText>{{ inscription.seed.seed }}</NumberText>
+          {{formatNumberWithComma(inscription.seed.seed)}}
         </div>
 
         <a
@@ -36,6 +36,7 @@
 
 <script setup>
 import { useLayoutStore } from '@/stores'
+import { formatNumberWithComma } from '@/utils/number'
 
 defineProps({
   isLoading: {


### PR DESCRIPTION
When using `<NumberText>` in `InscriptionList.vue`, the data passed to `<NumberText>` is stale even if `inscriptions` is updated properly.

This fix bypasses the `NumberText` component and formats the `seed` directly. There is probably a better solution to keeping `NumberText` in sync but this solves the problem mentioned in #3 

I don't know VUE well enough to fix `NumberText` directly but it seems to be an issue with `slotContent` being called with stale information and not being reactive